### PR TITLE
Fixed benchmarks.benchmark path, fixed Store.index_length

### DIFF
--- a/benchmarks/benchmark_decryption.py
+++ b/benchmarks/benchmark_decryption.py
@@ -1,10 +1,9 @@
-import sys.path
+import sys
 import os.path
-# Import from sibling directory
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
+from benchmarks.benchmark import benchmark_precise
 from scarab import generate_pair
-from benchmark import benchmark_precise
 from common.utils import binary
 
 

--- a/benchmarks/benchmark_encryption.py
+++ b/benchmarks/benchmark_encryption.py
@@ -1,10 +1,9 @@
-import sys.path
+import sys
 import os.path
-# Import from sibling directory
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
+from benchmarks.benchmark import benchmark
 from scarab import generate_pair
-from benchmark import benchmark
 from common.utils import binary
 
 

--- a/benchmarks/benchmark_key_generation.py
+++ b/benchmarks/benchmark_key_generation.py
@@ -1,5 +1,9 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
+
+from benchmarks.benchmark import benchmark
 from scarab import generate_pair
-from benchmark import benchmark
 
 
 benchmark(generate_pair, 100, verbose=True)

--- a/benchmarks/benchmark_op_and.py
+++ b/benchmarks/benchmark_op_and.py
@@ -1,12 +1,10 @@
-import sys.path
-import os.path
-# Import from sibling directory
+import os
+import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
+from benchmarks.benchmark import benchmark
 from scarab import generate_pair
-from benchmark import benchmark
 from common.utils import binary
-
 
 pk, sk = generate_pair()
 index = binary(42, size=8)

--- a/benchmarks/benchmark_op_xor.py
+++ b/benchmarks/benchmark_op_xor.py
@@ -1,10 +1,9 @@
-import sys.path
-import os.path
-# Import from sibling directory
+import os
+import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
 from scarab import generate_pair
-from benchmark import benchmark
+from benchmarks.benchmark import benchmark
 from common.utils import binary
 
 

--- a/benchmarks/benchmark_store_retrieve.py
+++ b/benchmarks/benchmark_store_retrieve.py
@@ -1,10 +1,9 @@
-import sys.path
-import os.path
-# Import from sibling directory
+import os
+import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
+from benchmarks.benchmark import benchmark
 from scarab import generate_pair
-from benchmark import benchmark
 from common.utils import binary
 from server import Store
 
@@ -12,7 +11,7 @@ from server import Store
 store = Store(record_size=20, record_count=20, fill='random')
 index = 2
 pk, sk = generate_pair()
-eq = pk.encrypt(binary(index, size=store.index_length), sk)
+eq = pk.encrypt(binary(index, size=store.index_bits), sk)
 
 
 def func():


### PR DESCRIPTION
Now the benchmarks can be run from any directory and still play well with Pycharm syntax highlighting. Also fixed the Store.index_length variable name.
